### PR TITLE
WINDUP-1966 Showing values in tooltips

### DIFF
--- a/reporting/impl/src/main/resources/reports/resources/css/tech-report-punchcard.css
+++ b/reporting/impl/src/main/resources/reports/resources/css/tech-report-punchcard.css
@@ -110,3 +110,81 @@ table.technologiesPunchCard thead,
 table.technologiesPunchCard tbody tr {
     display: table;
 }
+
+/* Tooltip container */
+.table-tooltip {
+    position: relative;
+}
+
+/* Tooltip text */
+.table-tooltip .table-tooltiptext {
+    visibility: hidden;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+
+    position: absolute;
+    z-index: 1;
+
+    font-size: 14pt;
+    padding: 5px;
+
+    /*left tooltip*/
+    top: 10px;
+    right: 85%;
+
+    opacity: 0;
+    transition: opacity 1s;
+}
+
+.table-tooltip:hover .table-tooltiptext {
+    visibility: visible;
+    opacity: 1;
+}
+
+.table-tooltip .table-tooltiptext::after {
+    position: absolute;
+    border-width: 5px;
+    border-style: solid;
+
+    /* To the right of the tooltip */
+    content: "";
+    top: 50%;
+    left: 100%;
+    margin-top: -5px;
+}
+
+.sectorView.table-tooltip .table-tooltiptext {
+    background-color: #1155CC;
+}
+.sectorView.table-tooltip .table-tooltiptext::after {
+    border-color: transparent transparent transparent #1155CC;
+}
+
+.sectorConnect.table-tooltip .table-tooltiptext {
+    background-color: #38761D;
+}
+.sectorConnect.table-tooltip .table-tooltiptext::after {
+    border-color: transparent transparent transparent #38761D;
+}
+
+.sectorStore.table-tooltip .table-tooltiptext {
+    background-color: #F4B400;
+}
+.sectorStore.table-tooltip .table-tooltiptext::after {
+    border-color: transparent transparent transparent #F4B400;
+}
+
+.sectorSustain.table-tooltip .table-tooltiptext {
+    background-color: #DB4437;
+}
+.sectorSustain.table-tooltip .table-tooltiptext::after {
+    border-color: transparent transparent transparent #DB4437 ;
+}
+
+.sectorExecute.table-tooltip .table-tooltiptext {
+    background-color: #674EA7;
+}
+.sectorExecute.table-tooltip .table-tooltiptext::after {
+    border-color: transparent transparent transparent #674EA7;
+}

--- a/reporting/impl/src/main/resources/reports/templates/techReport-punchCard.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/techReport-punchCard.ftl
@@ -146,7 +146,12 @@
                                         </#if>
                                         <!-- count: ${count?c}   max: ${maxForThisBox?c}   getLogaritmicDistribution(): ${ log?c } x 5 = ${ log * 5.0 } -->
 
-                                        <td class="circle size${ log?is_number?then((log * 5.0)?ceiling, "X")} sector sector${sectorTag.title}" data-count="${countInteger?c}"><#-- The circle is put here by CSS :after --></td>
+                                        <td class="circle size${ log?is_number?then((log * 5.0)?ceiling, "X")} sector sector${sectorTag.title} table-tooltip" data-count="${countInteger?c}">
+                                            <#-- The circle is put here by CSS :after -->
+                                            <#if countInteger gt 0>
+                                            <span class="table-tooltiptext">${countInteger?c}</span>
+                                            </#if>
+                                        </td>
                                     </#if>
                                 <#else>
                                     <td>No technology sectors defined.</td>


### PR DESCRIPTION
Added tooltips to show bubble's values when the mouse hover over a bubble.
In the screenshot some examples (tooltips have been "forced" to appear all together)
![screenshot from 2018-05-21 19-52-16](https://user-images.githubusercontent.com/7288588/40322672-6dc07a64-5d33-11e8-9d40-25a439e0d248.png)


